### PR TITLE
Remove windows creds hack

### DIFF
--- a/_references/rcs-credentials.md
+++ b/_references/rcs-credentials.md
@@ -27,7 +27,7 @@ using the credentials to authenticate to your cluster.
 
 ### <a name="download"></a> Download credentials
 
-1. Log in to the control panel at http://mycluster.rackspacecloud.com.
+1. Log in to the control panel at [http://mycluster.rackspacecloud.com](http://mycluster.rackspacecloud.com).
 
 2. Click the gear icon next to your cluster name and select **Download Credentials**.
 
@@ -48,4 +48,4 @@ using the credentials to authenticate to your cluster.
 
 6. Load your credentials and use them to interact with your cluster:
   * (_Linux and Mac OSX users_) Run `source docker.env`.
-  * (_Windows users_) See [Load Docker environment from the command line on Windows](/docs/tutorials/load-docker-environment-on-windows/).
+  * (_Windows users_) See [Load Docker environment from the command line on Windows]({{site.baseurl}}/docs/tutorials/load-docker-environment-on-windows/).

--- a/_references/rcs-credentials.md
+++ b/_references/rcs-credentials.md
@@ -44,37 +44,8 @@ using the credentials to authenticate to your cluster.
     By default, the files are unzipped into a unique directory, for example, **70a73a74-140b-4c37-bb06-cc113c8a8713**.
     You might want to rename that directory to something easier to remember, such as the name of the cluster.
 
-5. If you are on Windows and use CMD or PowerShell, follow the instructions in the [Create a Windows Script](#windows)
-    section.
+5. Open a command terminal and change to the credentials directory.
 
-6. Open a command terminal and change to the credentials directory.
-
-7. Load your credentials and use them to interact with your cluster:
+6. Load your credentials and use them to interact with your cluster:
   * (_Linux and Mac OSX users_) Run `source docker.env`.
   * (_Windows users_) See [Load Docker environment from the command line on Windows](/docs/tutorials/load-docker-environment-on-windows/).
-
-### <a name="windows"></a> Create a Windows script
-The cluster credentials zip file includes a Bash script, **docker.env**,
-that defines the environment variables necessary for authenticating to your cluster.
-Use the following instructions to create an equivalent script in CMD or PowerShell.
-
-1. Open **docker.env** and note the IP address of your cluster. It is on the line
-    that defines the DOCKER_HOST variable.
-
-2. To create a CMD script, create a file named **docker.cmd** and populate it
-    with the following content. Replace `<ipAddress>` with the IP address of your cluster.
-
-    ```batch
-    set DOCKER_HOST=tcp://<ipAddress>:2376
-    set DOCKER_TLS_VERIFY=1
-    set DOCKER_CERT_PATH=%~dp0
-    ```
-
-3. To create a PowerShell script, create a file named **docker.ps1** and populate it
-    with the following content. Replace `<ipAddress>` with the IP address of your cluster.
-
-    ```powershell
-    $env:DOCKER_HOST="tcp://<ipAddress>:2376"
-    $env:DOCKER_TLS_VERIFY=1
-    $env:DOCKER_CERT_PATH=$PSScriptRoot
-    ```

--- a/_tutorials/load-docker-environment-on-windows.md
+++ b/_tutorials/load-docker-environment-on-windows.md
@@ -71,6 +71,18 @@ Windows supported by Docker. To load a Docker environment in PowerShell, perform
     replacing `default` with the name of your Docker host.
 3. Verify that your Docker environment was initialized properly by running `docker version`.
 
+You may encounter the following error message when loading your Rackspace Container Service credentials:
+
+```powershell
+docker.ps1 cannot be loaded because running scripts is disabled on this system.
+```
+
+Run the following command to enable running PowerShell scripts. Then, run `docker.ps1` again.
+
+```powershell
+> Set-ExecutionPolicy -Scope CurrentUser Unrestricted
+```
+
 [powershell-doc]: https://technet.microsoft.com/en-us/library/ms714469.aspx
 
 #### <a name="bash"></a> Bash


### PR DESCRIPTION
Now that docker.ps1 and docker.cmd are included in the credentials zip, we don't need to make them ourselves. Huzzah!