### PR TITLE
Hiding the docs promo boxes on /docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-<section class="docs-section featured-articles">
+<section class="docs-section featured-articles" style="display: none;">
   <div class="section-container">
     <div class="section-grid">
       <div class="intro">


### PR DESCRIPTION
- Fixes #439 

I chose to do this via inline style so I didn't have to deal with a PR in nexus-control to do this via styles. Thoughts @ktbartholomew ?