### PR TITLE
Remove anchors from section headings

### DIFF
--- a/_M2/_000-best-practices-template.md
+++ b/_M2/_000-best-practices-template.md
@@ -66,12 +66,9 @@ End the section by directly recommending one option, if that's possible:
 **Current Recommendation:** Kubernetes
 -->
 
-<a name="resources"></a>
 ### Resources
 
 <!--
-Set the <a name="resources"></a> anchor above the Resources section heading so links come to the top of the section.
-
 If a reference is cited by a number in the text such as [(1)](#resources), include it in a numbered list here.
 
 If the text links to or hints at another source beneficial to readers, include it in a bulleted list here.

--- a/_best-practices/001-container-design-philosophy.md
+++ b/_best-practices/001-container-design-philosophy.md
@@ -46,7 +46,6 @@ design their stacks for their orchestrator of choice directly. What
 the future holds for Swarm is still to be determined, but the gist of
 Docker Swarm's added benefits are currently unclear.
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/002-container-ecosystem-docker-swarm.md
+++ b/_best-practices/002-container-ecosystem-docker-swarm.md
@@ -46,7 +46,6 @@ design their stacks for their orchestrator of choice directly. What
 the future holds for Swarm is still to be determined, but the gist of
 Docker Swarm's added benefits are currently unclear.
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/003-container-ecosystem-kubernetes.md
+++ b/_best-practices/003-container-ecosystem-kubernetes.md
@@ -184,7 +184,6 @@ In addition to the positive publicity in blog posts, the community is showing it
 interest by participating in Kubernetes' development: as of April 2015, Kubernetes averaged 
 around 400-500 commits per week and a very substantial following of almost 300 contributors.
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/004-container-ecosystem-mesos-openstack.md
+++ b/_best-practices/004-container-ecosystem-mesos-openstack.md
@@ -78,7 +78,6 @@ most to those most focused on application development:
 > to the forefront, and this naturally begs the question of which kind of controller will 
 > ultimately be in charge of the application clusters of the future.[(2)](#resources)
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article

--- a/_best-practices/005-container-ecosystem-openshift.md
+++ b/_best-practices/005-container-ecosystem-openshift.md
@@ -60,7 +60,6 @@ mission-critical IT shop will require a full top-to-bottom
 adoption of RedHat’s container and virtualization products, if both
 types of workloads will be co-located.
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/006-container-technologies-docker.md
+++ b/_best-practices/006-container-technologies-docker.md
@@ -178,7 +178,6 @@ being addressed by several technologies and should be in a much better
 state at a future date. For more on this, read
 [Docker best practices: data and stateful applications](/docs/best-practices/docker-best-practices-data-stateful-applications).
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/007-container-technologies-market-analysis.md
+++ b/_best-practices/007-container-technologies-market-analysis.md
@@ -168,7 +168,6 @@ and presents them as a single entity.
 
 > OpenShift can integrate with both OpenStack and Project Atomic, but OpenShift Enterprise may require top-to-bottom adoption of RedHat’s container and virtualization products.
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/008-container-technologies-networking.md
+++ b/_best-practices/008-container-technologies-networking.md
@@ -115,7 +115,6 @@ seriously evaluate and test.
 **Current Recommendation**: Weave (based on project attention, evolution,
 and funding)
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/009-container-technologies-operating-systems.md
+++ b/_best-practices/009-container-technologies-operating-systems.md
@@ -59,7 +59,6 @@ container dependency management and fault recovery.
 - **journald**: A system logging methodthat provides secure aggregation and attribution of container
 logs.
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/010-container-technologies-orchestration-clusters.md
+++ b/_best-practices/010-container-technologies-orchestration-clusters.md
@@ -522,7 +522,6 @@ and comparing key elements of their functionality [(Table 2)](#compare-features)
 
 **Current Recommendation:** Kubernetes
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/011-container-technologies-registration-discover.md
+++ b/_best-practices/011-container-technologies-registration-discover.md
@@ -147,7 +147,6 @@ In terms of which technology to use:
 
 **Current Recommendation:** etcd
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/012-container-technologies-scheduling-management.md
+++ b/_best-practices/012-container-technologies-scheduling-management.md
@@ -162,7 +162,6 @@ In terms of which technology to use:
 
 **Current Recommendation:** Mesos
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/013-docker-best-practices-container-linking.md
+++ b/_best-practices/013-docker-best-practices-container-linking.md
@@ -121,7 +121,6 @@ An alternative to container linking that is becoming an industry standard is to 
 service registration and discovery tool. If all the services that are available to your containers are known (registered) and can easily be located (discovered), there is no need to define specific links between services in multiple containers. You can read more about this at
 [Introduction to container technologies: registration and discovery of container services](../container-technologies-registration-discover/).
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/014-docker-best-practices-data-stateful-applications.md
+++ b/_best-practices/014-docker-best-practices-data-stateful-applications.md
@@ -180,7 +180,6 @@ map a data volume container to a block storage device and share that container w
 to introduce an additional management layer,
 just as you can [map a data volume](#mapping) so that the host knows it by one name and the container knows it by another name.
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/015-docker-best-practices-dockerfile.md
+++ b/_best-practices/015-docker-best-practices-dockerfile.md
@@ -175,7 +175,6 @@ creation and utilization of Dockerfiles to build your container images.
 Expressing exactly what you want is key
 to ensuring that users of your image have the right experience.
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_best-practices/016-docker-best-practices-image-repository.md
+++ b/_best-practices/016-docker-best-practices-image-repository.md
@@ -71,7 +71,6 @@ The default behavior for `docker push` is to push to the central
 Docker Hub Registry; alternatively, you can push your image to your own private
 Docker registry. After your image is running, log in to your private registry rather than the central registry with `docker login http(s)://<YOUR_DOMAIN>:<PORT>`.
 
-<a name="resources"></a>
 ### Resources
 
 Numbered citations in this article:

--- a/_getting-started/003-carina-cli.md
+++ b/_getting-started/003-carina-cli.md
@@ -12,7 +12,7 @@ topics:
 
 This tutorial demonstrates how to install and configure the Carina client so that you can use it to launch and control Docker Swarm clusters on a Carina endpoint. The `carina` command-line interface is a self-contained binary written in Go, so installation involves downloading a binary, making it executable, adding it to your path, and then configuring it with credentials.
 
-### Prerequisites <a name="Prereq"></a>
+### Prerequisites
 
 A Carina account. If you do not already have one, create a free account (no credit card required) by following the [sign up process](https://app.getcarina.com/app/signup).
 

--- a/_tutorials/029-docker-networking-basics.md
+++ b/_tutorials/029-docker-networking-basics.md
@@ -16,7 +16,7 @@ Docker encourages an application architecture with multiple interdependent conta
 rather than a single container providing many services&mdash;for example, a web application
 container that relies upon a caching container. Multiple solutions facilitate
 the networking of containers, but this tutorial covers two basic
-options: [Docker links](#links) and the [ambassador pattern](#ambassador).
+options: [Docker links](#docker-links) and the [ambassador pattern](#ambassador-pattern).
 
 **Note:** Weave is a commonly recommended solution, but because it requires
 privileged access to the Docker host, it is not an option with container as a service
@@ -25,7 +25,7 @@ providers, such as Carina.
 This tutorial describes how to network Docker containers so that they can communicate
 among themselves.
 
-### <a name="links"></a> Docker links
+### Docker links
 Docker links enable containers that are *on the same host* to communicate.
 
 When you run a container, the `--link` flag connects the new container, the _target_,
@@ -40,7 +40,7 @@ limits your topology and hinders scalability and availability.
 
 ![Docker links topology]({% asset_path connect-docker-containers-with-links/docker-links-topology.svg %})
 
-### <a name="ambassador"></a> Ambassador pattern
+### Ambassador pattern
 The ambassador pattern uses Docker links with specialized _ambassador_ containers to
 enable communication across Docker hosts. Rather than the target container communicating
 directly with the source container, the target container communicates with the _target ambassador_

--- a/_tutorials/030-connect-docker-containers-with-links.md
+++ b/_tutorials/030-connect-docker-containers-with-links.md
@@ -25,7 +25,7 @@ A Docker host using [Linux][docker-linux], [Docker Toolbox][docker-toolbox], or 
 [docker-toolbox]: https://www.docker.com/toolbox
 [carina]: http://app.getcarina.com/
 
-### <a name="connect"></a> Connect two containers with a Docker link
+### Connect two containers with a Docker link
 
 1. [Load your Docker host environment](/docs/tutorials/load-docker-environment-on-mac/).
 
@@ -76,7 +76,7 @@ You now have two containers that can communicate via a Docker link.
 
 ![Docker Link Topology]({% asset_path connect-docker-containers-with-links/docker-links-topology.svg %})
 
-### <a name="inspect"></a> Inspect the linked containers
+### Inspect the linked containers
 
 Follow these instructions to learn more about the information provided by the Docker link
 and how the containers use it to communicate.

--- a/_tutorials/034-troubleshooting-port-unavailable.md
+++ b/_tutorials/034-troubleshooting-port-unavailable.md
@@ -22,7 +22,7 @@ Error response from daemon: Cannot start container 1b48146:  Bind for 0.0.0.0:80
 
 This error message indicates that the Docker host already has a container published
 to the specified port. To resolve this error, you must either
-[remove the container that is using the port](#remove-container) or [use another port](#alternate-port).
+[remove the container that is using the port](#remove-the-containers-already-using-the-port) or [use another port](#publish-to-an-alternative-port).
 
 Alternatively, if you are using Carina or Docker Swarm, the following error message is displayed:
 
@@ -33,10 +33,10 @@ Error response from daemon: unable to find a node with port 80 available
 
 This error message indicates that every node in the cluster already has a container published
 to the specified port. To resolve this error, you must either
-[remove the containers that are using the port](#remove-container),
-[use another port](#alternate-port), or [add capacity to the cluster](#grow-cluster).
+[remove the containers that are using the port](#remove-the-containers-already-using-the-port),
+[use another port](#publish-to-an-alternative-port), or [add capacity to the cluster](#add-capacity-to-the-cluster).
 
-### <a name="remove-container"></a> Remove the containers already using the port
+### Remove the containers already using the port
 1. To identify the containers that are using the port, run the following command,
     changing `<port>` to the port number that you want to use.
 
@@ -55,7 +55,7 @@ to the specified port. To resolve this error, you must either
 
 You can now run your container using the port number.
 
-### <a name="alternate-port"></a> Publish to an alternative port
+### Publish to an alternative port
 Use the `--publish` flag to publish the container to an alternative port on the Docker host. For example,
 if the container exposes port 80 and you have selected port 8081 as the alternative port,
 you would use `--publish 8081:80` when running your Docker container. For example:
@@ -64,7 +64,7 @@ you would use `--publish 8081:80` when running your Docker container. For exampl
 $ docker run --detach --publish 8081:80 nginx
 ```
 
-### <a name="grow-cluster"></a> Add capacity to the cluster
+### Add capacity to the cluster
 If you are using Carina, add segments to add capacity.
 
 1. Log in to the [Carina control panel](https://app.getcarina.com).

--- a/_tutorials/051-docker-install-linux.md
+++ b/_tutorials/051-docker-install-linux.md
@@ -12,7 +12,7 @@ topics:
 
 This tutorial describes how to install and set up Docker on Linux distributions, such as Ubuntu or Debian.
 
-### <a name="install"></a> Install Docker
+### Install Docker
 The following steps use Ubuntu. If you are not using Ubuntu, you can find installation
 instructions for your Linux distribution on [the Docker website](https://docs.docker.com/installation/).
 
@@ -96,7 +96,7 @@ instructions for your Linux distribution on [the Docker website](https://docs.do
        https://docs.docker.com/userguide/
      ````
 
-### <a name="sudo"></a> Configure Docker to run without sudo
+### Configure Docker to run without sudo
 If you want to use the `docker` command without always prefixing it with `sudo`, follow
 these instructions. For more information about the security impacts of adding a user
 to the docker group, see [Docker daemon attack surface][daemon-security].

--- a/_tutorials/054-load-docker-environment-on-linux.md
+++ b/_tutorials/054-load-docker-environment-on-linux.md
@@ -17,11 +17,11 @@ topics:
 
 This tutorial describes how to load a Docker environment on Linux.
 
-###<a name="prerequisites"></a>Prerequisite
+### Prerequisite
 
 [Install Docker on Linux](/docs/tutorials/docker-install-linux/)
 
-###<a name="load"></a>Load the Docker environment
+### Load the Docker environment
 
 1. Open a command terminal.
 2. If you are using Carina, [download your credentials][get-cluster-creds].
@@ -30,5 +30,5 @@ This tutorial describes how to load a Docker environment on Linux.
 
 [get-cluster-creds]: {{site.baseurl}}/docs/references/carina-credentials/
 
-###<a name="references"></a>References
+### References
 [Docker 101]({{ site.baseurl }}/docs/tutorials/docker-101/)

--- a/_tutorials/055-load-docker-environment-on-mac.md
+++ b/_tutorials/055-load-docker-environment-on-mac.md
@@ -17,11 +17,11 @@ topics:
 
 This tutorial describes how to load a Docker environment on Mac OS X.
 
-###<a name="prerequisites"></a>Prerequisite
+### Prerequisite
 
 [Install Docker on Mac OS X](/docs/tutorials/docker-install-mac/)
 
-####<a name="load"></a>Load the Docker environment
+#### Load the Docker environment
 1. Open a command terminal.
 2. Load your Docker host environment variables by using one of the following methods:
   * If you are using Carina, [download your credentials][get-cluster-creds].
@@ -32,5 +32,5 @@ This tutorial describes how to load a Docker environment on Mac OS X.
 
 [get-cluster-creds]: {{site.baseurl}}/docs/references/carina-credentials/
 
-###<a name="references"></a>References
+### References
 [Docker 101]({{ site.baseurl }}/docs/tutorials/docker-101/)

--- a/_tutorials/056-load-docker-environment-on-windows.md
+++ b/_tutorials/056-load-docker-environment-on-windows.md
@@ -26,15 +26,15 @@ text commands and _terminal_ is the graphical window that hosts a shell.
   * [PowerShell](#powershell)
   * [Bash](#bash)
 * [Terminals](#terminals)
-  * [Windows Command Prompt](#cmd-prompt)
+  * [Windows Command Prompt](#windows-command-prompt)
   * [Mintty](#mintty)
   * [Alternatives](#alternatives)
 
-### <a name="prerequisites"></a> Prerequisite
+### Prerequisite
 
 [Install Docker on Windows](/docs/tutorials/docker-install-windows/)
 
-### <a name="shells"></a> Shells
+### Shells
 After installing Docker Toolbox on Windows, you have three shells available for
 interacting with Docker: CMD, PowerShell, and Bash. Although each shell provides
 different commands and syntax, all are capable of interacting with Docker.
@@ -43,7 +43,7 @@ different commands and syntax, all are capable of interacting with Docker.
 * [PowerShell](#powershell)
 * [Bash](#bash)
 
-#### <a name="cmd"></a> CMD
+#### CMD
 [CMD][cmd-doc] is the standard Windows shell. To load a Docker environment in
 CMD, perform the following steps:
 
@@ -58,7 +58,7 @@ CMD, perform the following steps:
 [cmd-doc]: http://ss64.com/nt/syntax.html
 [get-cluster-creds]: {{site.baseurl}}/docs/references/carina-credentials/
 
-#### <a name="powershell"></a> PowerShell
+#### PowerShell
 [PowerShell][powershell-doc] is built on Microsoft .NET and is designed to
 work with .NET objects instead of raw text. It is distributed with all versions of
 Windows supported by Docker. To load a Docker environment in PowerShell, perform the following steps:
@@ -85,7 +85,7 @@ Run the following command to enable running PowerShell scripts. Then, run `docke
 
 [powershell-doc]: https://technet.microsoft.com/en-us/library/ms714469.aspx
 
-#### <a name="bash"></a> Bash
+#### Bash
 [Bash][bash-doc] is a UNIX shell installed with [Git for Windows][git-for-windows],
 which is included with Docker Toolbox. If you are using Bash from another source, such as Cygwin or MinGW,
 the Docker environment setup remains the same.
@@ -109,22 +109,22 @@ To load a Docker environment in Bash, perform the following steps:
 [git-for-windows]: https://git-for-windows.github.io
 [bash-doc]: http://www.gnu.org/software/bash/manual/bash.html
 
-### <a name="terminals"></a> Terminals
+### Terminals
 After installing Docker Toolbox on Windows, you have two terminals available:
 Windows Command Prompt and mintty. If you do not want to use either of those terminals,
 some alternatives are available to you.
 
-* [Windows Command Prompt](#cmd-prompt)
+* [Windows Command Prompt](#windows-command-prompt)
 * [Mintty](#mintty)
 * [Alternatives](#alternatives)
 
-#### <a name="cmd-prompt"></a> Windows Command Prompt
+#### Windows Command Prompt
 The Command Prompt is the standard Windows terminal. By default all console applications, including cmd.exe,
 are hosted in the Windows Command Prompt.
 
 ![Windows Command Prompt Screenshot]({% asset_path load-docker-environment-on-windows/cmd.png %})
 
-#### <a name="mintty"></a> Mintty
+#### Mintty
 [Mintty][mintty] is the terminal used by the Git Bash application installed with [Git for Windows][git-for-windows],
 which is included with Docker Toolbox. With mintty, you can perform the following actions:
 
@@ -145,9 +145,9 @@ in the [CMD](#cmd) or [PowerShell](#powershell) section of this tutorial to set 
 ![Git Bash Screenshot]({% asset_path load-docker-environment-on-windows/gitbash.png %})
 
 [mintty]: https://mintty.github.io
-[troubleshooting-tty]: {{site.baseurl}}/docs/references/troubleshooting-cannot-enable-tty-mode-on-windows/#ssh
+[troubleshooting-tty]: {{site.baseurl}}/docs/references/troubleshooting-cannot-enable-tty-mode-on-windows/#use-ssh-to-connect-to-the-docker-host
 
-#### <a name="alternatives"></a>Alternatives
+#### Alternatives
 Some alternative terminals provide useful features, such as improved copy and paste,
 window resizing, and tabs. Overall they are more customizable than the standard
 Windows terminal used by CMD and PowerShell.
@@ -155,7 +155,7 @@ Windows terminal used by CMD and PowerShell.
 * [ConsoleZ](#consolez)
 * [ConEmu](#conemu)
 
-##### <a name="consolez"></a> ConsoleZ
+##### ConsoleZ
 [ConsoleZ][consolez] is a terminal emulator that can be used with any shell.
 
 1. [Download ConsoleZ from GitHub][consolez-downloads].
@@ -171,7 +171,7 @@ In the following screenshot, ConsoleZ is configured with tabs for each shell (CM
 [consolez]: https://github.com/cbucher/console/wiki
 [consolez-downloads]: https://github.com/cbucher/console/wiki/Downloads
 
-##### <a name="conemu"></a> ConEmu
+##### ConEmu
 [ConEmu][conemu], short for Console Emulator, is a terminal emulator that can be used with any shell.
 A unique feature of ConEmu is that it can be configured to replace the [default terminal
 in Windows][conemu-default-terminal], such that cmd.exe or any console application will
@@ -196,7 +196,7 @@ In the following screenshot, ConEmu is configured with tabs for each shell (CMD,
 [conemu-settings]: https://conemu.github.io/en/Settings.html
 [conemu-default-terminal]: https://conemu.github.io/en/DefaultTerminal.html
 
-### <a name="references"></a> References
+### References
 * [CMD syntax][cmd-doc]
 * [PowerShell syntax](http://ss64.com/ps/syntax.html)
 * [Bash syntax](http://ss64.com/bash/syntax.html)

--- a/_tutorials/058-carina-credentials.md
+++ b/_tutorials/058-carina-credentials.md
@@ -27,7 +27,7 @@ The credentials zip file contains the following files:
 This article provides instructions for downloading the credentials zip file and
 using the credentials to authenticate to your cluster.
 
-### <a name="download"></a> Download credentials
+### Download credentials
 
 1. Log in to the control panel at [http://mycluster.rackspacecloud.com](http://mycluster.rackspacecloud.com).
 

--- a/_tutorials/060-troubleshooting-cannot-enable-tty-mode-on-windows.md
+++ b/_tutorials/060-troubleshooting-cannot-enable-tty-mode-on-windows.md
@@ -25,13 +25,13 @@ Cygwin users might also encounter this problem.
 
 This article provides some possible workarounds.
 
-* [Use SSH to connect to the Docker host](#ssh)
-* [Use the CMD terminal with the Bash shell](#cmd-with-bash)
-* [Use the CMD terminal with the Windows shell](#cmd)
-* [Use PowerShell](#powershell)
-* [Use an alternative terminal](#other-terminals)
+* [Use SSH to connect to the Docker host](#use-ssh-to-connect-to-the-docker-host)
+* [Use the CMD terminal with the Bash shell](#use-the-cmd-terminal-with-the-bash-shell)
+* [Use the CMD terminal with the Windows shell](#use-the-cmd-terminal-with-the-windows-shell)
+* [Use PowerShell](#use-powershell)
+* [Use an alternative terminal](#use-an-alternative-terminal)
 
-### <a name="ssh"></a> Use SSH to connect to the Docker host
+### Use SSH to connect to the Docker host
 Continuing in Git Bash, use the `docker-machine ssh` command to connect to the Docker host,
 and then start an interactive shell:
 
@@ -53,7 +53,7 @@ and then start an interactive shell:
     $ docker exec --interactive --tty test sh
     ```
 
-### <a name="cmd-with-bash"></a> Use the CMD terminal with the Bash shell
+### Use the CMD terminal with the Bash shell
 Switch to the CMD terminal with the Bash shell, which is similar to using Git Bash.
 
 1. Run the following commands, which start a Bash shell and then load the Docker environment named `default`.
@@ -70,7 +70,7 @@ Switch to the CMD terminal with the Bash shell, which is similar to using Git Ba
     $ docker run --interactive --tty ubuntu sh
     ```
 
-### <a name="cmd"></a>Use the CMD terminal with the Windows shell
+### Use the CMD terminal with the Windows shell
 Switch to the CMD terminal with the standard Windows shell.
 
 1. Run the following command, copy the output, and then paste it into the command prompt.
@@ -87,7 +87,7 @@ Switch to the CMD terminal with the standard Windows shell.
     $ docker run --interactive --tty ubuntu sh
     ```
 
-### <a name="powershell"></a> Use PowerShell
+### Use PowerShell
 
 1. Run the following command to load the Docker environment named `default`.
   If you are working with a different Docker environment, replace `default` with the appropriate name.
@@ -102,7 +102,7 @@ Switch to the CMD terminal with the standard Windows shell.
     $ docker run --interactive --tty ubuntu sh
     ```
 
-### <a name="other-terminals"></a>Use an alternative terminal
+### Use an alternative terminal
 Use an alternative terminal, such as [ConEmu][conemu] or [ConsoleZ][consolez] and your preferred shell (Bash, CMD, or PowerShell).
 
 [run-shell-docs]: https://docs.docker.com/articles/basics/#running-an-interactive-shell

--- a/_tutorials/061-preview-jekyll-with-docker-on-linux.md
+++ b/_tutorials/061-preview-jekyll-with-docker-on-linux.md
@@ -24,14 +24,14 @@ you do not need to install Ruby or Jekyll on your local machine.
 
 [jekyll]: https://jekyllrb.com/
 
-## <a name="prerequisites"></a> Prerequisites
+## Prerequisites
 * [Docker](http://docs.docker.com/linux/step_one/)
 * An existing Jekyll site on your local file system. If you do not have
   an existing site, a good way to get started quickly is to download a [Jekyll theme][jekyll-themes].
 
 [jekyll-themes]: https://github.com/jekyll/jekyll/wiki/Themes
 
-## <a name="steps"></a> Steps
+## Steps
 
 1. Open a command terminal and change to your Jekyll site directory.
 
@@ -130,7 +130,7 @@ See [Troubleshooting common problems](/docs/tutorials/troubleshooting/).
 
 For additional assistance, ask the [community](https://community.getcarina.com/) for help or join us in IRC at [#carina on Freenode](http://webchat.freenode.net/?channels=carina).
 
-### <a name="resources"></a>Resources
+### Resources
 
 * [Jekyll documentation](https://jekyllrb.com/docs/home/)
 * [Using Jekyll with GitHub Pages](https://jekyllrb.com/docs/github-pages/)

--- a/_tutorials/062-preview-jekyll-with-docker-on-mac.md
+++ b/_tutorials/062-preview-jekyll-with-docker-on-mac.md
@@ -24,7 +24,7 @@ you do not need to install Ruby or Jekyll on your local machine.
 
 [jekyll]: https://jekyllrb.com/
 
-## <a name="prerequisites"></a> Prerequisites
+## Prerequisites
 * [Docker Toolbox][docker-toolbox]
 * An existing Jekyll site on your local file system. If you do not have
   an existing site, a good way to get started quickly is to download a [Jekyll theme][jekyll-themes].
@@ -38,7 +38,7 @@ you do not need to install Ruby or Jekyll on your local machine.
 [docker-toolbox]: https://www.docker.com/toolbox
 [jekyll-themes]: https://github.com/jekyll/jekyll/wiki/Themes
 
-## <a name="steps"></a> Steps
+## Steps
 
 1. Open a command terminal and change to your Jekyll site directory.
 
@@ -148,7 +148,7 @@ Refresh the page in your web browser to see your changes.
 
 [jekyll-image]: https://hub.docker.com/r/grahamc/jekyll/
 
-## <a name="troubleshooting"></a>Troubleshooting
+## Troubleshooting
 You might encounter the following issue when running the preview script:
 
 * <a name="troubleshooting-missing-config"></a> The \_config.yml file is not picked up by Jekyll
@@ -175,7 +175,7 @@ See [Troubleshooting common problems](/docs/tutorials/troubleshooting/).
 
 For additional assistance, ask the [community](https://community.getcarina.com/) for help or join us in IRC at [#carina on Freenode](http://webchat.freenode.net/?channels=carina).
 
-### <a name="resources"></a>Resources
+### Resources
 
 * [Jekyll documentation](https://jekyllrb.com/docs/home/)
 * [Using Jekyll with GitHub Pages](https://jekyllrb.com/docs/github-pages/)

--- a/_tutorials/063-preview-jekyll-with-docker-on-windows.md
+++ b/_tutorials/063-preview-jekyll-with-docker-on-windows.md
@@ -25,7 +25,7 @@ you do not need to install Ruby or Jekyll on your local machine.
 
 [jekyll]: https://jekyllrb.com/
 
-## <a name="prerequisites"></a> Prerequisites
+## Prerequisites
 * [Docker Toolbox][docker-toolbox]
 * An existing Jekyll site on your local file system. If you do not have
   an existing site, a good way to get started quickly is to download a [Jekyll theme][jekyll-themes].
@@ -39,7 +39,7 @@ you do not need to install Ruby or Jekyll on your local machine.
 [docker-toolbox]: https://www.docker.com/toolbox
 [jekyll-themes]: https://github.com/jekyll/jekyll/wiki/Themes
 
-## <a name="steps"></a> Steps
+## Steps
 
 1. Open a command terminal and change to your Jekyll site directory.
 
@@ -224,7 +224,7 @@ Refresh the page in your web browser to see your changes.
 
 [jekyll-image]: https://hub.docker.com/r/grahamc/jekyll/
 
-## <a name="troubleshooting"></a>Troubleshooting
+## Troubleshooting
 You might encounter the following issues when running the preview script.
 
 * <a name="troubleshooting-stop-jekyll"></a>Ctrl + C does not stop Jekyll
@@ -256,7 +256,7 @@ See [Troubleshooting common problems](/docs/tutorials/troubleshooting/).
 
 For additional assistance, ask the [community](https://community.getcarina.com/) for help or join us in IRC at [#carina on Freenode](http://webchat.freenode.net/?channels=carina).
 
-### <a name="resources"></a>Resources
+### Resources
 
 * [Jekyll documentation](https://jekyllrb.com/docs/home/)
 * [Using Jekyll with GitHub Pages](https://jekyllrb.com/docs/github-pages/)


### PR DESCRIPTION
Now that we are using the redcarpet renderer with the `with_toc_data` plugin, we do not need to manually specify anchors for section headings.

Fixes #423

cc @everett-toews 