### PR TITLE
Fixed link for first box

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@ layout: default
       </div>
       <div class="resource">
         <div class="image">
-          <a href="docs/tutorials/getting-started-on-carina/"><img src="{% asset_path resource-1.svg %}" alt="chairs"></a>
+          <a href="docs/overview-of-carina/"><img src="{% asset_path resource-1.svg %}" alt="chairs"></a>
         </div>
         {% for post in site.getting-started %}{% if post.url == '/docs/overview-of-carina/' %}
           <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>


### PR DESCRIPTION
That first box should link to the Overview of Carina article. It was instead linking to a stale version of the Getting started on Carina article.