### PR TITLE
Ensure jekyll escapes curly braces used in go fmt

### DIFF
--- a/_tutorials/007-data-volume-containers.md
+++ b/_tutorials/007-data-volume-containers.md
@@ -75,7 +75,7 @@ The output of this `docker run` command is the container ID.
 Discover the volume mount information of your DVC.
 
 ```bash
-$ docker inspect --format '{{ .Mounts }}' data
+$ docker inspect --format '{% raw %}{{ .Mounts }}{% endraw %}' data
 [{
   9e22f6557f43c57ddb14e28f0fd54cdda1f6ab7e60a2380523f7bfd6390d0556
   /var/lib/docker/volumes/9e22f6557f43c57ddb14e28f0fd54cdda1f6ab7e60a2380523f7bfd6390d0556/_data

--- a/_tutorials/023-docker-swarm-carina.md
+++ b/_tutorials/023-docker-swarm-carina.md
@@ -81,7 +81,7 @@ for service discovery.
 To retrieve the discovery token for a cluster, run the following command:
 
 ```
-$ docker inspect -f "{{index .Config.Cmd 6}}" $(docker ps -aq -f name=swarm-manager -n 1)
+$ docker inspect -f "{% raw %}{{index .Config.Cmd 6}}{% endraw %}" $(docker ps -aq -f name=swarm-manager -n 1)
 token://<cluster_id>
 ```
 

--- a/_tutorials/030-connect-docker-containers-with-links.md
+++ b/_tutorials/030-connect-docker-containers-with-links.md
@@ -35,7 +35,7 @@ can communicate over the network.
     port is `5000`. This is the port number over which the containers will communicate.
 
     ```bash
-    $ docker inspect --format "{{ .Config.ExposedPorts }}" app
+    $ docker inspect --format "{% raw %}{{ .Config.ExposedPorts }}{% endraw %}" app
     map[5000/tcp:{}]
     ```
 

--- a/_tutorials/031-connect-docker-containers-ambassador-pattern.md
+++ b/_tutorials/031-connect-docker-containers-ambassador-pattern.md
@@ -36,12 +36,10 @@ so that they can communicate over the network and across Docker hosts. For infor
     port is `5000`. This is the port number over which the ambassador will
     communicate with the source container.
 
-    {% raw %}
     ```bash
     $ docker inspect --format "{% raw %}{{ .Config.ExposedPorts }}{% endraw %}" app
     map[5000/tcp:{}]
     ```
-    {% endraw %}
 
 1. Run an ambassador container named `app-ambassador`.
 

--- a/_tutorials/031-connect-docker-containers-ambassador-pattern.md
+++ b/_tutorials/031-connect-docker-containers-ambassador-pattern.md
@@ -38,7 +38,7 @@ so that they can communicate over the network and across Docker hosts. For infor
 
     {% raw %}
     ```bash
-    $ docker inspect --format "{{ .Config.ExposedPorts }}" app
+    $ docker inspect --format "{% raw %}{{ .Config.ExposedPorts }}{% endraw %}" app
     map[5000/tcp:{}]
     ```
     {% endraw %}

--- a/_tutorials/032-application-logging.md
+++ b/_tutorials/032-application-logging.md
@@ -121,7 +121,12 @@ Currently, only `UDP` connections are allowed via the specified `port` value.
 
 The following example shows the options that Docker might use to log to a Fluentd server:
 
-`$ docker run --log-driver=fluentd --log-opt fluentd-address=localhost:24224 --log-opt fluentd-tag=docker.{{.Name}}`
+```
+$ docker run \
+  --log-driver=fluentd \
+  --log-opt fluentd-address=localhost:24224 \
+  --log-opt fluentd-tag=docker.{% raw %}{{.Name}}{% endraw %}
+```
 
 **Note:** A container using this logging method will immediately stop if it cannot connect to the Fluentd server.
 


### PR DESCRIPTION
Right now any usage of curly braces for string formatting in Docker commands is being stripped by Jekyll:

![](http://imgur.com/yPTNs1j.png)

This is because `{{` is reserved and needs to be escaped with `{% raw %}` tags.